### PR TITLE
Explicitly document that setTag(Response)Action doesn't overwrite exiting tags

### DIFF
--- a/pdns/dnsdistdist/docs/rules-actions.rst
+++ b/pdns/dnsdistdist/docs/rules-actions.rst
@@ -1335,6 +1335,7 @@ The following actions exist.
 
   Associate a tag named ``name`` with a value of ``value`` to this query, that will be passed on to the response.
   Subsequent rules are processed after this action.
+  This function will not overwrite an existing tag. If the tag already exists it will keep its original value.
   Note that this function was called :func:`TagAction` before 1.6.0.
 
   :param string name: The name of the tag to set
@@ -1346,6 +1347,7 @@ The following actions exist.
 
   Associate a tag named ``name`` with a value of ``value`` to this response.
   Subsequent rules are processed after this action.
+  This function will not overwrite an existing tag. If the tag already exists it will keep its original value.
   Note that this function was called :func:`TagResponseAction` before 1.6.0.
 
   :param string name: The name of the tag to set


### PR DESCRIPTION
### Short description
It surprised me that setTagAction and setTagResponseAction didn't overwrite existing tag values. This adds a line to the docs so that future users aren't surprised by this.

### Checklist
I have:
- [X] read the [CONTRIBUTING.md](https://github.com/PowerDNS/pdns/blob/master/CONTRIBUTING.md) document
- [ ] compiled this code
- [X] tested this code
- [X] included documentation (including possible behaviour changes)
- [X] documented the code
- [ ] added or modified regression test(s)
- [ ] added or modified unit test(s)
